### PR TITLE
Allows for https

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "url-patch",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "wrangle squirly urls",
   "main": "patcher.js",
   "scripts": {

--- a/patcher.js
+++ b/patcher.js
@@ -1,9 +1,14 @@
 var patchProtocol = (url) => {
   var protocolStr = 'http://';
-  if(!url.startsWith(protocolStr)) {
-    url = protocolStr + url;
+  if(url.substr(0,5) == 'https') {
+    return url;
   }
-  return url;
+  else if (url.substr(0,4) == 'http') {
+    return url;
+  }
+  else {
+    return protocolStr + url;
+  }
 };
 
 var patchTrailingSlash = (url) => {


### PR DESCRIPTION
I love using: https://github.com/RallySoftware/jenkins-build-light/

The Jenkins instance I work with sits behind https. I have made a few small changes to allow for https. Please see the complementary PR at: https://github.com/RallySoftware/jenkins-build-light/pull/13
